### PR TITLE
Use enum for debug-param

### DIFF
--- a/FW/src/App.cpp
+++ b/FW/src/App.cpp
@@ -21,13 +21,8 @@ App::App() :
  */
 void App::Run() {
 
-#if DEBUG == 1
-    System::System::Initialize(true);
-    m_watch.Init(true);
-#else
-    System::System::Initialize();
-    Watch.Init();
-#endif
+    System::System::Initialize(Debug::MODE);
+    m_watch.Init(Debug::MODE);
 
     m_stateMachine.Start();
     m_tickTimer.Start();

--- a/FW/src/BCDWatch.cpp
+++ b/FW/src/BCDWatch.cpp
@@ -91,7 +91,7 @@ BCDWatch::BCDWatch(FreeRTOS::Queue<Events, EventQueueLength> *eventQueue) :
     Brightness = 0xFF;
 }
 
-void BCDWatch::Init(const bool debug) {
+void BCDWatch::Init(Debug::Mode mode) {
     // Init all led pins as outputs
     LedS00.InitOutput();
     LedS01.InitOutput();
@@ -115,7 +115,7 @@ void BCDWatch::Init(const bool debug) {
     LedH03.InitOutput();
     LedH10.InitOutput();
     LedH11.InitOutput();
-    if(debug) {
+    if(mode == Debug::DebugMode) {
         LedH12_DTx.InitAlternate(0, GPIO::Type::PushPull, GPIO::Speed::VeryHigh);
         LedH13_DRx.InitAlternate(0, GPIO::Type::PushPull, GPIO::Speed::VeryHigh);
         DbgSerial.Init(115200);

--- a/FW/src/BCDWatch.hpp
+++ b/FW/src/BCDWatch.hpp
@@ -12,12 +12,11 @@
 #include "Button.hpp"
 #include "Queue.hpp"
 
-
 class BCDWatch {
 public:
     BCDWatch(FreeRTOS::Queue<Events, EventQueueLength> *eventQueue);
 
-    void Init(const bool debug = false);
+    void Init(Debug::Mode mode = Debug::NormalMode);
 private:
     GPIO::Pin LedS00;
     GPIO::Pin LedS01;

--- a/FW/src/Debug.hpp
+++ b/FW/src/Debug.hpp
@@ -8,6 +8,17 @@
 
 namespace Debug
 {
+    enum Mode {
+        NormalMode = 0,
+        DebugMode
+    };
+
+#ifdef DEBUG
+    static const Mode MODE = DebugMode;
+#else  // DEBUG
+    static const Mode MODE = NormalMode;
+#endif  // DEBUG
+
     class Debug  {
     public:
         Debug(UART::SerialPort *port);

--- a/FW/src/HAL/System.cpp
+++ b/FW/src/HAL/System.cpp
@@ -12,7 +12,7 @@ namespace System {
     volatile uint32_t System::m_delayCounter = 0;
     bool System::m_resumed = false;
 
-    void System::Initialize(const bool debug) {
+    void System::Initialize(Debug::Mode mode) {
         LL_FLASH_SetLatency(LL_FLASH_LATENCY_1);
 
         if(LL_FLASH_GetLatency() != LL_FLASH_LATENCY_1)
@@ -80,7 +80,7 @@ namespace System {
         LL_RCC_SetUSARTClockSource(LL_RCC_USART1_CLKSOURCE_PCLK2);
         LL_RCC_SetI2CClockSource(LL_RCC_I2C1_CLKSOURCE_PCLK1);
 
-        if(debug) {
+        if(mode == Debug::DebugMode) {
             // In debug mode, keep SWD active in standby mode
             LL_DBGMCU_EnableDBGStandbyMode();
         }

--- a/FW/src/HAL/System.hpp
+++ b/FW/src/HAL/System.hpp
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include "stm32l0xx_ll_pwr.h"
 
+#include "Debug.hpp"
+
 namespace System {
 
 
@@ -32,7 +34,7 @@ namespace System {
 
     class System {
     public:
-        static void Initialize(const bool debug = false);
+        static void Initialize(Debug::Mode debug = Debug::NormalMode);
         static void EnableClock(const ClockHW clock);
         static void Delay(const uint32_t milliseconds);
         static void Reset();


### PR DESCRIPTION
I really like using enums with descriptive value names for parameters like "this mode or that", like the debug parameter. It makes reading the code very clear, as you immediately know what
```c++
my_function(Debug::DebugMode);
```
means. While if you happen to see a call like this when browsing a code base:
```c++
my_function(true);
```
You almost always have to go hunt down the header to know what that means. Modern editors often help, but it's still an extra step to just reading. It gets even more interesting when you have calls like:
```c++
my_function(true, true, false);
```
;)

Also, I created a debug mode variable in the Debug class, just to move the ```#ifdef DEBUG``` to one place, rather than risk having to sprinkle it across the code, if more classes need to know if they should be in debug mode or not. Code interspersed with #ifdefs tend to get ugly fast, imho, and often the less tried case tends to break (which I think happened here, actually). That's more me thinking out loud in the code though.

What do you think?