### PR TITLE
New take on button-events

### DIFF
--- a/FW/src/Drivers/Button.cpp
+++ b/FW/src/Drivers/Button.cpp
@@ -1,48 +1,69 @@
 #include "Button.hpp"
 
-#define BUTTONPRESS_LIMIT_LOW     (2)
-#define BUTTONPRESS_LIMIT_SHORT  (15)
-#define BUTTONPRESS_LIMIT_LONG   (25)
-#define BUTTONPRESS_LIMIT_HOLD   (50)
+// Limits for regular press, long press and button hold, measured in
+// deciseconds(??).
+#define BUTTONPRESS_LIMIT_LOW     (0)
+#define BUTTONPRESS_LIMIT_SHORT  (10)
+//#define BUTTONPRESS_LIMIT_LONG   (25)
+//#define BUTTONPRESS_LIMIT_HOLD   (50)
 
 
 namespace Button {
-    PushButton::PushButton(GPIO::Pin *pin, FreeRTOS::Queue<Events, EventQueueLength> *eventQueue) : 
-        Task("Btn", Task::LowPriority) 
-    {
-        m_pin = pin;
-        m_eventQueue = eventQueue;
-    }
+    PushButton::PushButton(GPIO::Pin *pin, FreeRTOS::Queue<Events, EventQueueLength> *eventQueue)
+        : Task("Btn", Task::LowPriority), m_pin(pin), m_eventQueue(eventQueue)
+    { }
 
 
     void PushButton::Run() {
         InitPeriod(ButtonPeriodMilliseconds);
 
         uint32_t downCounter = 0;
+        uint32_t upCounter = 0;
         Events event = Events::None;
-        while(1) {
-            event = Events::None;
+        while (true) {
             
-            if(m_pin->Get()) {
+            if (m_pin->Get()) {
+                // Button is pressed down.
                 downCounter++;
 
-                if(downCounter > BUTTONPRESS_LIMIT_HOLD) {
-                    event = Events::ButtonHold;
-                    m_eventQueue->Enqueue(&event, 0);
-                }
-            }
-            else {
-                if(downCounter > BUTTONPRESS_LIMIT_LOW && downCounter < BUTTONPRESS_LIMIT_SHORT) {
-                    event = Events::ButtonPress;
-                    m_eventQueue->Enqueue(&event, ButtonPeriodMilliseconds / 2);
-                }
-                else if(downCounter > BUTTONPRESS_LIMIT_LONG && downCounter < BUTTONPRESS_LIMIT_HOLD) {
-                    event = Events::ButtonLongPress;
-                    m_eventQueue->Enqueue(&event, ButtonPeriodMilliseconds / 2);
+                if (downCounter > BUTTONPRESS_LIMIT_SHORT) {
+                    if (event == Events::None) {
+                        // There's no previously recorded button event, or it
+                        // happened too far back. Send a long press.
+                        event = Events::ButtonLongPress;
+                        m_eventQueue->Enqueue(&event, ButtonPeriodMilliseconds / 2);
+                    } else if (event == Events::ButtonPress || event == Events::ButtonHold) {
+                        // The previous event was a button press or we're still
+                        // holding down. Send a button hold event.
+                        event = Events::ButtonHold;
+                        m_eventQueue->Enqueue(&event, 0);
+                    }
                 }
 
-                if(downCounter > 0)
-                    downCounter = 0;
+                upCounter = 0;
+            } else {
+                // Button is up.
+                upCounter++;
+
+                if (downCounter > 0 && downCounter < BUTTONPRESS_LIMIT_SHORT) {
+                    event = Events::ButtonPress;
+                    m_eventQueue->Enqueue(&event, ButtonPeriodMilliseconds / 2);
+                } else if (event == Events::ButtonLongPress || event == Events::ButtonHold) {
+                    // The button was released and the previously sent event
+                    // was wither long press or hold, clear the saved event, so
+                    // we don't go back into hold again until we do another
+                    // click-hold.
+                    event = Events::None;
+                }
+
+                downCounter = 0;
+            }
+
+            if (upCounter > BUTTONPRESS_LIMIT_SHORT) {
+                // If the last button press ended more than the button press
+                // limit time back, clear the press event that would trigger a
+                // button hold on long press.
+                event = Events::None;
             }
 
             EndPeriod();

--- a/FW/src/HAL/RTC.hpp
+++ b/FW/src/HAL/RTC.hpp
@@ -8,6 +8,11 @@
 namespace RealTimeClock {
     struct Time
     {
+        enum TickMode {
+            TICK_PROPAGATE,
+            TICK_ISOLATED
+        };
+
         Time() : H(0), M(0), S(0) {}
         Time(const uint8_t h, const uint8_t m, const uint8_t s) : H(h), M(m), S(s) {}
 
@@ -15,17 +20,21 @@ namespace RealTimeClock {
         uint8_t M;
         uint8_t S;
 
-        void TickS() {
+        void TickS(TickMode mode = TICK_PROPAGATE) {
             if(++S >= 60) {
                 S = 0;
-                TickM();
+                if (mode == TICK_PROPAGATE) {
+                    TickM();
+                }
             }
         }
 
-        void TickM() {
+        void TickM(TickMode mode = TICK_PROPAGATE) {
             if(++M >= 60) {
                 M = 0;
-                TickH();
+                if (mode == TICK_PROPAGATE) {
+                    TickH();
+                }
             }
         }
 
@@ -33,6 +42,14 @@ namespace RealTimeClock {
             if(++H >= 24) {
                 H = 0;
             }
+        }
+
+        bool operator==(const Time &t) {
+            return H == t.H && M == t.M && S == t.S;
+        }
+
+        bool operator!=(const Time &t) {
+            return !(*this == t);
         }
     };
 

--- a/FW/src/States/DisplayTime.cpp
+++ b/FW/src/States/DisplayTime.cpp
@@ -21,9 +21,9 @@ namespace States {
     State* DisplayTime::Tick(BCDWatch *watch) {
         State::Tick(watch);
 
-        // Set correct time
-        if(this->m_stateTime % 1000 == 0) {
-            this->m_time.TickS();
+        RealTimeClock::Time previous_time = m_time;
+        watch->Rtc.GetTime(this->m_time);
+        if (m_time != previous_time) {
             watch->Display.Set(this->m_time);
         }
 

--- a/FW/src/States/SetTime.cpp
+++ b/FW/src/States/SetTime.cpp
@@ -12,32 +12,48 @@ namespace States {
     SetTime SetTime::Instance;
 
     void SetTime::Init(BCDWatch *watch) {
-        this->m_dutycycle = DUTYCYCLE_MAX;
-        this->m_dutycycleSign = -1;
-        this->m_idleTimer = 0;
-        watch->Rtc.GetTime(this->m_time);
-        this->m_time.S = 0;
+        m_dutycycle = DUTYCYCLE_MAX;
+        m_dutycycleSign = -1;
+        m_idleTimer = 0;
+        watch->Rtc.GetTime(m_time);
+        m_time.S = 0;
 
-        watch->Display.Set(this->m_time);
+        watch->Display.Set(m_time);
+
+        m_mode = MODE_M;
     }
 
 
     void SetTime::DeInit(BCDWatch *watch) {
-        watch->Rtc.SetTime(this->m_time);
+        watch->Rtc.SetTime(m_time);
     }
 
 
     State* SetTime::Tick(BCDWatch *watch) {
-        this->m_dutycycle += this->m_dutycycleSign;
-        if(this->m_dutycycle <= DUTYCYCLE_MIN) {
-            this->m_dutycycleSign = 1;
+        m_dutycycle += m_dutycycleSign;
+        if(m_dutycycle <= DUTYCYCLE_MIN) {
+            m_dutycycleSign = 1;
         }
-        else if( this->m_dutycycle >= DUTYCYCLE_MAX) {
-            this->m_dutycycleSign  =-1;
+        else if( m_dutycycle >= DUTYCYCLE_MAX) {
+            m_dutycycleSign  =-1;
         }
-        watch->Display.Dim(Display::Column::ALL, this->m_dutycycle);
+        if (m_mode == MODE_M) {
+            watch->Display.Dim(Display::Column::S0, 25);
+            watch->Display.Dim(Display::Column::S1, 25);
+            watch->Display.Dim(Display::Column::M0, m_dutycycle);
+            watch->Display.Dim(Display::Column::M1, m_dutycycle);
+            watch->Display.Dim(Display::Column::H0, 25);
+            watch->Display.Dim(Display::Column::H1, 25);
+        } else if (m_mode == MODE_H) {
+            watch->Display.Dim(Display::Column::S0, 25);
+            watch->Display.Dim(Display::Column::S1, 25);
+            watch->Display.Dim(Display::Column::M0, 25);
+            watch->Display.Dim(Display::Column::M1, 25);
+            watch->Display.Dim(Display::Column::H0, m_dutycycle);
+            watch->Display.Dim(Display::Column::H1, m_dutycycle);
+        }
 
-        if(this->m_idleTimer++ >= IDLE_TIME_LIMIT) {
+        if(m_idleTimer++ >= IDLE_TIME_LIMIT) {
             return &DisplayTime::Instance;
         }
 
@@ -45,23 +61,56 @@ namespace States {
     }
 
     State* SetTime::ButtonPress(BCDWatch *watch) {
-        this->m_time.TickM();
-        watch->Display.Set(this->m_time);
+        switch (m_mode) {
+        case MODE_M:
+            // Don't increase the hours if the minutes wrap from 59 to 0.
+            m_time.TickM(RealTimeClock::Time::TICK_ISOLATED);
+            break;
+        case MODE_H:
+            m_time.TickH();
+            break;
+        default:
+            watch->Debug.Write("Unknown SetTime::Mode: ");
+            watch->Debug.Write(static_cast<uint8_t>(m_mode));
+            watch->Debug.Write("\r\n");
+            break;
+        }
+        watch->Display.Set(m_time);
 
-        this->m_idleTimer = 0;
+        m_idleTimer = 0;
 
         return this;
     }
 
     State* SetTime::ButtonLongPress(BCDWatch *watch) {
+        if (m_mode == MODE_M) {
+            m_mode = MODE_H;
+            return this;
+        }
+        m_mode = MODE_M;
+        m_time.S = 0;
         return &DisplayTime::Instance;
     }
 
     State* SetTime::ButtonHold(BCDWatch *watch) {
-        this->m_time.TickM();
-        watch->Display.Set(this->m_time);
 
-        this->m_idleTimer = 0;
+        switch (m_mode) {
+        case MODE_M:
+            m_time.TickM();
+            break;
+        case MODE_H:
+            m_time.TickH();
+            break;
+        default:
+            watch->Debug.Write("Unknown SetTime::Mode: ");
+            watch->Debug.Write(static_cast<uint8_t>(m_mode));
+            watch->Debug.Write("\r\n");
+            break;
+        }
+
+        watch->Display.Set(m_time);
+
+        m_idleTimer = 0;
 
         return this;
     }

--- a/FW/src/States/SetTime.hpp
+++ b/FW/src/States/SetTime.hpp
@@ -7,6 +7,11 @@ namespace States {
 
     class SetTime : public State {    
     public:
+        enum Mode : uint8_t {
+            MODE_M,
+            MODE_H
+        };
+
         void Init(BCDWatch *watch) override;
         void DeInit(BCDWatch *watch) override;
         State* Tick(BCDWatch *watch) override;
@@ -16,6 +21,7 @@ namespace States {
 
         static SetTime Instance;
     private:
+        Mode m_mode;
         RealTimeClock::Time m_time;
         uint8_t m_dutycycle;
         int8_t m_dutycycleSign;


### PR DESCRIPTION
Press then release less than press-timeout: button press.
Press then release longer than press-timeout: long press.
Button press then press-release longer than press-timeout: button hold.

Also, while setting time, ticking minutes from 59 to 0 won't tick
hours. Dim the number you're not currently setting.

Also fix LED transition flicker.